### PR TITLE
Add support for Processing instructions

### DIFF
--- a/jsonml-utils.js
+++ b/jsonml-utils.js
@@ -84,9 +84,38 @@ if (typeof module === 'object') {
 	 * @return {boolean}
 	 */
 	var isElement = JsonML.isElement = function(jml) {
-		return isArray(jml) && ('string' === typeof jml[0]);
+		return isArray(jml) && ('string' === typeof jml[0]) && (jml[0].charAt(0) !== '?');
 	};
 
+	/**
+	 * @param {*} jml
+	 * @return {boolean}
+	 */
+	var isProcessingInstruction = JsonML.isProcessingInstruction = function(jml) {
+		return isArray(jml) && ('string' === typeof jml[0]) && (jml[0].charAt(0) === '?');
+	};
+
+	/**
+	 * @param {*} jml
+	 * @return {string}
+	 */
+	var getTarget = JsonML.getTarget = function(jml) {
+		if (!isProcessingInstruction(jml)) {
+			throw new SyntaxError('invalid JsonML');
+		}
+		return jml[0].substring(1);
+	};
+
+	/**
+	 * @param {*} jml
+	 * @return {string}
+	 */
+	var getData = JsonML.getData = function(jml) {
+		if (!isProcessingInstruction(jml)) {
+			throw new SyntaxError('invalid JsonML');
+		}
+		return jml[1];
+	};
 	/**
 	 * @param {*} jml
 	 * @return {boolean}
@@ -196,7 +225,7 @@ if (typeof module === 'object') {
 
 		} else if (child && 'object' === typeof child) {
 			if (isArray(child)) {
-				if (!isElement(child)) {
+				if (!isElement(child) && !isProcessingInstruction(child)) {
 					throw new SyntaxError('invalid JsonML');
 				}
 

--- a/jsonml-xml.js
+++ b/jsonml-xml.js
@@ -375,7 +375,7 @@ if (typeof module === 'object') {
 	 */
 	JsonML.fromXMLText = function(xmlText, filter) {
 		var elem = parseXML(xmlText);
-		elem = elem && (elem.ownerDocument || elem).documentElement;
+		elem = elem && (elem.ownerDocument || elem);
 
 		return fromXML(elem, filter);
 	};

--- a/jsonml-xml.js
+++ b/jsonml-xml.js
@@ -253,6 +253,10 @@ if (typeof module === 'object') {
 
 				addChildren(elem, filter, jml);
 
+				if (jml[0] === '' && jml.length === 2) {
+					jml = jml[1]
+				}
+
 				// filter result
 				if ('function' === typeof filter) {
 					jml = filter(jml, elem);

--- a/jsonml-xml.js
+++ b/jsonml-xml.js
@@ -62,6 +62,8 @@ if (typeof module === 'object') {
 
 		} else if (tag.charAt(0) === '!') {
 			return document.createComment(tag === '!' ? '' : tag.substr(1)+' ');
+		} else if (tag.charAt(0) === '?') {
+			return document.createProcessingInstruction(tag === '!' ? '' : tag.substr(1), '');
 		}
 
 		return document.createElement(tag);
@@ -99,7 +101,8 @@ if (typeof module === 'object') {
 				if (child.nodeType === 3) { // text node
 					elem.nodeValue += child.nodeValue;
 				}
-
+			} else if (elem.nodeType === 7) {
+				elem.data = child.data;
 			} else if (elem.canHaveChildren !== false) {
 				elem.appendChild(child);
 			}
@@ -264,6 +267,17 @@ if (typeof module === 'object') {
 				// free references
 				elem = null;
 				return str;
+			case 7: // ProcessingInstruction node
+				var jml = ['?'+elem.target, elem.data]
+
+				// filter result
+				if ('function' === typeof filter) {
+					jml = filter(jml, elem);
+				}
+
+				// free references
+				elem = null;
+				return jml;
 			case 10: // doctype
 				jml = ['!'];
 

--- a/test/xmlTests.js
+++ b/test/xmlTests.js
@@ -340,4 +340,21 @@ test('JsonML.fromXMLText/.toXMLText roundtrip, comments', function() {
 	same(actual, expected);
 });
 
+test('JsonML.fromXMLText/.toXMLText roundtrip, processing instructions', function() {
+
+	var expected =
+		'<?some-pi and its data?>' +
+		'<foo>' +
+			'<?another-pi with data?>' +
+		'</foo>';
+
+	// JsonML will strip the XML Declaration
+	var input = '<?xml version="1.0"?>' + expected;
+
+	var jml = JsonML.fromXMLText(input);
+	var actual = JsonML.toXMLText(jml);
+
+	same(actual, expected);
+});
+
 }catch(ex){alert(ex);}


### PR DESCRIPTION
This adds support for [Processing Instructions](https://www.w3.org/TR/2008/REC-xml-20081126/#sec-pi). These are defined in the XML 1.0 Specification as follows:

> ```
> [16] PI            ::= '<?' PITarget (S (Char* - (Char* '?>' Char*)))? '?>'
> [17] PITarget      ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
> ```

## Rationale

The [JsonML website](http://www.jsonml.org/xml/) states:
> Processing instruction nodes are inherently ignored in JsonML. There does not seem to be a useful analogy which is consistent with the intent of JsonML.

But to provide a truly lossless way to convert arbitrary XML to JsonML and back, IMHO they *should be preserved*:

- As per [Section 2.6 of the XML 1.0 Specification](https://www.w3.org/TR/2008/REC-xml-20081126/#sec-pi), passing PIs through to an application is a *"MUST"* requirement.

- Accordingly, PIs are also preserved during [XML Canonicalization (C14N)](https://www.w3.org/TR/xml-c14n), which is a way to normalize the physical appearance of an XML document while retaining its logic. The retention of PIs indicates that they are not insignificant (by contrast, comment support is optional and things like DTD or XML Declaration are lost during C14N).

## JsonML grammar modifications

Thus, I added support for Processing Instructions:

```bnf
element
   = '[' tag-name ',' attributes ',' element-list ']'
   | '[' tag-name ',' attributes ']'
   | '[' tag-name ',' element-list ']'
   | '[' tag-name ']'
   | '[' pi-target ',' string ']'
   | string
   ;
pi-target
   = "?" + string
```

Processing Instructions can't be mistaken for elements since `#x3F` (= Question Mark [`?`]) is not a valid `NameStartChar` (which means that a `tag-name` can't begin with a question mark):

> ```
> [2]  Char          ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] /* any Unicode character, excluding the surrogate blocks, FFFE, and FFFF. */
> [3]  S             ::= (#x20 | #x9 | #xD | #xA)+
> [4]  NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
> [4a] NameChar	   ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
> [5]  Name          ::= NameStartChar (NameChar)*
> [40] STag          ::= '<' Name (S Attribute)* S? '>'
> ```

One sublety is that when a document contains one or more Processing Instructions as top-level constructs (besides the `documentElement`), then the resulting JsonML text will have a top level element with an empty string as `tag-name` and an `element-list` consisting of the PIs and the `documentElement` in the correct order.
This behaviour is consistent with the [handling of fragments in JsonML](https://github.com/mckamey/jsonml/blob/master/jsonml-utils.js#L70-L72).

Please have a look at the examples below and let me know what you think. Thanks in advance!

## Examples

Here's a simple example:

```xml
<foo><?a-single-pi with data?></foo>
```
The above XML document represented as JsonML:

```json
[
    "foo",
    [
        "?a-single-pi",
        "with data"
    ]
]
```

Here's a more complex example with has Processing Instructions at the document level:

```xml
<?some-pi and its data?>
<foo>
    <?another-pi with data?>
</foo>
<?third-pi?>
```

The above file will map to:

```json
[
    "",
    [
        "?some-pi",
        "and its data"
    ],
    "\n",
    [
        "foo",
        "\n    ",
        [
            "?another-pi",
            "with data"
        ],
        "\n"
    ],
    "\n",
    [
        "?third-pi",
        ""
    ]
]
```